### PR TITLE
Remove % sign from df output so awk math works

### DIFF
--- a/checks/inodes.yml
+++ b/checks/inodes.yml
@@ -1,5 +1,5 @@
 name: inodes
-command: "df -i | awk '(NR>1) && ($5 > 75){ print \"Running out of inodes on: \" $1, \":\", $5, \"used\"}' | grep 'used'"
+command: "df -i | tr -d '%' | awk '(NR>1) && ($5 > 75){ print \"Running out of inodes on: \" $1, \":\", $5, \"used\"}' | grep 'used'"
 expected_result: 1
 category:
   - base


### PR DESCRIPTION

### before

```
web-8226:~$ df -i | awk '(NR>1) && ($5 > 75){ print "Running out of inodes on: " $1, ":", $5, "used"}' | grep 'used'
Running out of inodes on: /dev/xvdb : 9% used
```

### after
```
web-8226:~$ df -i | tr -d '%' | awk '(NR>1) && ($5 > 75){ print "Running out of inodes on: " $1, ":", $5, "used"}' | grep 'used'
```