### PR TITLE
Make core_dumps check only print date and filename

### DIFF
--- a/checks/core_dumps.yml
+++ b/checks/core_dumps.yml
@@ -1,5 +1,5 @@
 name: core_dumps
-command: 'find $(dirname $(cat /proc/sys/kernel/core_pattern | cut -d " " -f1)) ! -empty -mtime -7 | grep ""'
+command: 'find $(dirname $(cat /proc/sys/kernel/core_pattern | cut -d " " -f1)) ! -empty -mtime -7 -type f -printf "%AY-%Am-%Ad %AH:%AM %f\n" | grep ""'
 expected_result: 1
 category:
   - base


### PR DESCRIPTION
Output of core_dumps check is trimmed down and more informational at a glance.

```
2015-11-05 19:32 core-php-fpm-11-25447-25447-28567-1446751951
```

Instead of the original output.

```
/mnt/tmp/cores
/mnt/tmp/cores/core-php-fpm-11-25447-25447-28567-1446751951
```