### PR TITLE
Add io errors check

### DIFF
--- a/checks/io_errors.yml
+++ b/checks/io_errors.yml
@@ -1,0 +1,9 @@
+name: io_error
+command: 'grep "I/O error" /var/log/kern.log'
+expected_result: 1
+category:
+  - base
+type: ssh
+user: root
+dependencies:
+  - ssh


### PR DESCRIPTION


## Output
```
{noformat:title=io_error                       on ded-11716.prod.hosting.acquia.com                  fail}
    ...812.982348] lost page write due to I/O error on xvda1
    Dec 10 22:07:27 $host kernel: [102305812.982352] Buffer I/O error on device xvda1, logical block 32407
    Dec 10 22:07:27 $host kernel: [102305812.982358] lost page write due to I/O error on xvda1
{noformat}
```