### PR TITLE
Adds a @pid accessor to runner, adds an optional key called 'timeout' to server manifests

### DIFF
--- a/lib/sof/runner.rb
+++ b/lib/sof/runner.rb
@@ -6,8 +6,6 @@ require 'net/ssh'
 require 'net/scp'
 require 'colorize'
 
-require 'timeout'
-
 module Sof
   class Runner
 
@@ -37,7 +35,7 @@ module Sof
     def run_checks(progress = 'Running checks')
       @results = []
       @total_time = Benchmark.realtime do
-        @results = Parallel.map_with_index(servers, :in_processes => 1, :progress => progress) do |server|
+        @results = Parallel.map_with_index(servers, :in_processes => @options.server_concurrency, :progress => progress) do |server|
           @pids << Process.pid
           checks = Sof::Check.load(server.categories)
           check_results = []

--- a/lib/sof/runner.rb
+++ b/lib/sof/runner.rb
@@ -6,10 +6,7 @@ require 'net/ssh'
 require 'net/scp'
 require 'colorize'
 
-# this should be fun.
 require 'timeout'
-
-require 'pry'
 
 module Sof
   class Runner

--- a/lib/sof/ssh.rb
+++ b/lib/sof/ssh.rb
@@ -10,7 +10,7 @@ class Ssh
 
   def initialize(server, echo:)
     @server = server
-    @ssh_options = { :port => server.port, :compression => false, :keys => server.keys }
+    @ssh_options = { :port => server.port, :compression => false, :keys => server.keys, :timeout => server.timeout }
     @ssh_retries = 10
     @echo = echo
   end

--- a/lib/sof/ssh.rb
+++ b/lib/sof/ssh.rb
@@ -10,7 +10,13 @@ class Ssh
 
   def initialize(server, echo:)
     @server = server
-    @ssh_options = { :port => server.port, :compression => false, :keys => server.keys, :timeout => server.timeout }
+
+    @ssh_options = if server.respond_to? :timeout
+                     { :port => server.port, :compression => false, :keys => server.keys, :timeout => server.timeout}
+                   else
+                     { :port => server.port, :compression => false, :keys => server.keys }
+                   end
+
     @ssh_retries = 10
     @echo = echo
   end

--- a/lib/sof/ssh.rb
+++ b/lib/sof/ssh.rb
@@ -11,11 +11,8 @@ class Ssh
   def initialize(server, echo:)
     @server = server
 
-    @ssh_options = if server.respond_to? :timeout
-                     { :port => server.port, :compression => false, :keys => server.keys, :timeout => server.timeout}
-                   else
-                     { :port => server.port, :compression => false, :keys => server.keys }
-                   end
+    @ssh_options = { :port => server.port, :compression => false, :keys => server.keys }
+    @ssh_options[:timeout] = server.timeout if server.respond_to? :timeout
 
     @ssh_retries = 10
     @echo = echo


### PR DESCRIPTION
This is a dependency of an internal ticket this sprint.

timeout: will be passed to ssh if it's defined in the manifest. If not, no big.